### PR TITLE
Move render blocking JS and CSS

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -49,6 +49,4 @@
     <% if (theme.rss) { %>
       <link rel="alternate" href="<%= url_for(theme.rss) %>" title="<%= config.title %>" type="application/atom+xml" />
     <% } %>
-    <!-- jquery -->
-    <%- js('lib/jquery/jquery.min') %>
 </head>

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -38,9 +38,6 @@
     <!-- title -->
     <title><%= page.title ? page.title : config.title %></title>
     <!-- styles -->
-    <%- css('lib/font-awesome/css/font-awesome.min') %>
-    <%- css('lib/meslo-LG/styles') %>
-    <%- css('lib/justified-gallery/justifiedGallery.min.css') %>
     <%- css('css/style') %>
     <!-- rss -->
     <% if (theme.rss === '' && config.feed && config.feed.path) { %>

--- a/layout/_partial/scripts.ejs
+++ b/layout/_partial/scripts.ejs
@@ -1,3 +1,5 @@
+<!-- jquery -->
+<%- js('lib/jquery/jquery.min') %>
 <%- js('lib/justified-gallery/jquery.justifiedGallery.min.js') %>
 <%- js('js/main') %>
 <!-- Google Analytics -->

--- a/layout/_partial/styles.ejs
+++ b/layout/_partial/styles.ejs
@@ -1,0 +1,5 @@
+<!-- styles -->
+<%- css('lib/font-awesome/css/font-awesome.min') %>
+<%- css('lib/meslo-LG/styles') %>
+<%- css('lib/justified-gallery/justifiedGallery.min.css') %>
+

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -15,6 +15,7 @@
       <%- partial('_partial/post/actions_mobile') %>
     <% } %>
     <%- partial('_partial/footer') %>
-    <%- partial('_partial/scripts') %>
 </body>
 </html>
+<%- partial('_partial/styles') %>
+<%- partial('_partial/scripts') %>


### PR DESCRIPTION
Hello,

Running Google's [PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/) test on cactus-dark theme shows some performance warnings about render blocking resources (both JS & CSS). 

This PR is a small change proposal to improve performance on crappy networks, by moving jquery and non-critical CSS file to the bottom of the page.

Related documentation :
 - [Blocking JS](https://developers.google.com/speed/docs/insights/BlockingJS)
 - [Optimize CSS Delivery](https://developers.google.com/speed/docs/insights/OptimizeCSSDelivery)