### PR TITLE
Prevent TOC overflow

### DIFF
--- a/source/css/_partial/post/actions_desktop.styl
+++ b/source/css/_partial/post/actions_desktop.styl
@@ -87,6 +87,8 @@
     clear: both
     text-align: right
     padding-top: 1rem
+    max-width: 20em
+    float: right
     a:hover
       color: $color-link
     .toc-level-1 > .toc-link


### PR DESCRIPTION
Stop TOC list in sidebar on large screens from overflowing into body. 23em is what's required for no margin. 20em is what's set in this change.