### PR TITLE
Added padding-right to: #header-post #share

### DIFF
--- a/source/css/_partial/post/actions_desktop.styl
+++ b/source/css/_partial/post/actions_desktop.styl
@@ -85,6 +85,7 @@
     clear: both
     text-align: right
     padding-top: 1rem
+    padding-right: 2rem
     li
       margin: 0
       display: block


### PR DESCRIPTION
Hi, I just added a `padding-righ: 2rem;` in `actions_desktop.styl`, to get these changes:

**before:**
![before](https://i.imgur.com/mTjMWMm.png)

**after:**
![after](https://i.imgur.com/41lPT9j.png)