### PR TITLE
Remove whitespaces in nav items to resolve layout issues.

### DIFF
--- a/layout/_partial/footer.ejs
+++ b/layout/_partial/footer.ejs
@@ -9,9 +9,9 @@
   <div class="footer-right">
     <nav>
       <ul>
-        <% for (var i in theme.nav) { %> 
-          <li><a href="<%- url_for(theme.nav[i]) %>"><%= __('nav.'+i).replace("nav.", "") %></a></li>
-        <% } %>
+        <% for (var i in theme.nav) { %><!--
+       --><li><a href="<%- url_for(theme.nav[i]) %>"><%= __('nav.'+i).replace("nav.", "") %></a></li><!--
+     --><% } %>
       </ul>
     </nav>
   </div>

--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -20,9 +20,9 @@
       <li class="icon">
         <a href="#" aria-label="<%- __('icons.menu') %>"><i class="fas fa-bars fa-2x"></i></a>
       </li>
-      <% for (var i in theme.nav) { %> 
-        <li><a href="<%- url_for(theme.nav[i]) %>"><%= __('nav.'+i).replace("nav.", "") %></a></li>
-      <% } %>
+      <% for (var i in theme.nav) { %><!--
+     --><li><a href="<%- url_for(theme.nav[i]) %>"><%= __('nav.'+i).replace("nav.", "") %></a></li><!--
+   --><% } %>
     </ul>
   </div>
 </header>

--- a/layout/_partial/post/actions_desktop.ejs
+++ b/layout/_partial/post/actions_desktop.ejs
@@ -5,9 +5,9 @@
   <span id="menu">
     <span id="nav">
       <ul>
-        <% for (var i in theme.nav) { %> 
-          <li><a href="<%- url_for(theme.nav[i]) %>"><%= __('nav.'+i).replace("nav.", "") %></a></li>
-        <% } %>
+        <% for (var i in theme.nav) { %><!--
+       --><li><a href="<%- url_for(theme.nav[i]) %>"><%= __('nav.'+i).replace("nav.", "") %></a></li><!--
+     --><% } %>
       </ul>
     </span>
     <br/>


### PR DESCRIPTION
Whitespaces between `li`s of `ul`s, which used to decribe nav items, can result extra spacing between items.

<img width="1235" alt="Screenshot 2021-10-10 PM 6 53 28" src="https://user-images.githubusercontent.com/8158163/136692627-17f2d548-b3c9-46e7-85b4-f57913e800af.png">

This PR resolves the above problem.