### PR TITLE
Add support to utteranc comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A responsive, clean and simple [Hexo](http://hexo.io) theme for a personal websi
 - Support for local search
 - Projects list
 - I18n support
-- Disqus integration
+- Disqus / Utterances
 - Google analytics / Baidu Tongji / [Umami Analytics](https://umami.is) 
 - Font Awesome icons
 - Simplicity
@@ -280,6 +280,10 @@ Only JQuery will be loaded from the specified CDN.
 
 ### Comments
 
+Cactus supports two commenting systems: [Disqus](https://disqus.com) and [Utterances](https://utteranc.es).
+
+#### Disqus
+
 First, create a site on Disqus: [https://disqus.com/admin/create/](http://disqus.com/admin/create/).
 
 Next, update the `_config.yml` file:
@@ -292,6 +296,27 @@ disqus:
 
 where `SITENAME` is the name you gave your site on Disqus.
 
+#### Utterances
+
+First, follow the instructions on the [oficial website](https://utteranc.es/) to setup an issue tracker Utterances will connect to.
+
+Next, update the `_config.yml` file:
+
+```yml
+utteranc:
+  enabled: true
+  repo: owner/githubrepo
+  issue_term: pathname
+  label: utteranc
+  theme: themename
+```
+
+where each of the parameters are the respective values ​​provided during the configuration of the Utterances:
+
+* `repo`:  the repository Utterances will connect to.
+* `issue_term`: the mapping between blog posts and GitHub issues.
+* `label`: the label that will be assigned to issues created by Utterances
+* `theme`: the selected Utterances theme.
 
 ### Code Highlighting
 

--- a/_config.yml
+++ b/_config.yml
@@ -146,6 +146,14 @@ disqus:
   enabled: false
   shortname: cactus-1
 
+# Fill in your Utterances data to enable Utterances comments
+utterances:
+  enabled: false
+  repo: owner/githubrepo
+  issue_term: pathname
+  label: Comment
+  theme: github-dark
+
 # Fill in your Google Analytics tracking ID to enable Google Analytics.
 google_analytics:
   enabled: false

--- a/layout/_partial/comments.ejs
+++ b/layout/_partial/comments.ejs
@@ -5,3 +5,10 @@
         </div>
     </div>
 <% } %>
+<% if(page.comments && theme.utterances.enabled){ %>
+    <div class="blog-post-comments">
+        <div id="utterances_thread">
+            <noscript><%= __('comments.no_js') %></noscript>
+        </div>
+    </div>
+<% } %>

--- a/layout/_partial/scripts.ejs
+++ b/layout/_partial/scripts.ejs
@@ -111,7 +111,7 @@
   <script async defer data-website-id="<%= theme.umami_analytics.id %>" src="<%= theme.umami_analytics.host %>/umami.js"></script>
 <% } %>
 <!-- Disqus Comments -->
-<% if (theme.disqus.enabled && theme.disqus.shortname){ %>
+<% if (page.comments && theme.disqus.enabled && theme.disqus.shortname){ %>
     <script type="text/javascript">
         var disqus_shortname = '<%= theme.disqus.shortname %>';
 
@@ -123,4 +123,26 @@
             (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
         }());
     </script>
+<% } %>
+<!-- utterances Comments -->
+<% if (page.comments && theme.utterances.enabled && theme.utterances.repo && theme.utterances.issue_term && theme.utterances.theme){ %>
+    <script type="text/javascript">
+      var utterances_repo = '<%= theme.utterances.repo %>';
+      var utterances_issue_term = '<%= theme.utterances.issue_term %>';
+      var utterances_label = '<%= theme.utterances.label %>';
+      var utterances_theme = '<%= theme.utterances.theme %>';
+
+      (function(){
+          var script = document.createElement('script');
+
+          script.src = 'https://utteranc.es/client.js';
+          script.setAttribute('repo', utterances_repo);
+          script.setAttribute('issue-term', 'pathname');
+          script.setAttribute('label', utterances_label);
+          script.setAttribute('theme', utterances_theme);
+          script.setAttribute('crossorigin', 'anonymous');
+          script.async = true;
+          (document.getElementById('utterances_thread')).appendChild(script);
+      }());
+  </script>
 <% } %>


### PR DESCRIPTION
Hi @probberechts!

This PR add support to [utteranc](https://utteranc.es/) comments widget. A lightweight comments widget built on GitHub issues. 😁

Use example in this page of my blog: https://mstuttgart.github.io/2018/01/linux-mint:-como-reiniciar-ambiente-grafico-mate-e-cinnamon/

![screenshot_2](https://user-images.githubusercontent.com/8174740/138380838-f4f89249-097e-491f-8384-7a1b86de8b25.png)

Thanks to build this awesome theme! 