### PR TITLE
Add fallback workaround to ensure menu always visible at very top of the page.

### DIFF
--- a/source/js/main.js
+++ b/source/js/main.js
@@ -59,7 +59,7 @@ $(document).ready(function() {
         var topDistance = menu.offset().top;
 
         // hide only the navigation links on desktop
-        if (!nav.is(":visible") && topDistance < 50) {
+        if (!nav.is(":visible") && (topDistance < 50 || window.scrollY === 0)) {
           nav.show();
         } else if (nav.is(":visible") && topDistance > 100) {
           nav.hide();


### PR DESCRIPTION
Workaround for issue #313 on Chrome.