### PR TITLE
Add canonical URL setting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -158,6 +158,8 @@ open_graph:
   twitter_id:
   google_plus:
 
+# specify canonical URL
+canonical_URL: true
 
 ##############################################################################
 # Plugins

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -77,4 +77,12 @@
 		</script>
 		<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_CHTML' async></script>
 	<% } %>
+  <% if (theme.canonical_URL){ %>
+    <!-- canonical url -->    
+    <% if (page.permalink) { %>
+      <link rel="canonical" href="<%= page.permalink %>" />
+    <% } else{ %>  
+      <link rel="canonical" href="<%= url %>" />
+    <% } %>
+  <% } %>
 </head>


### PR DESCRIPTION
Netlify automatically normalize URLs to lowercase, add canonical URL to improve SEO