### PR TITLE
feat: category/tag support on home page and as separate pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,22 @@ You have two options for the list of blog posts on the home page:
       show_all_posts: true
     ```
 
+
+### Category and Tag section on home page
+You can show a category and tag section on the home page by editing the hexo ```_config.yml``` file.
+
+  ```yml
+  # Show a Tags section on the home page
+  show_tags_section: true
+
+  # Show a Category section on the home page
+  show_category_section: true
+  ```
+The theme has a provision to make separate tags and category pages. For this, you need to follow these steps:
+- make a new hexo page.
+- changing the layout to ```tags``` for a tags page or ```categories``` for a categories page.
+- adding the relevant paths in your nav menu.
+
 ### Projects list
 
 Create a projects file `source/_data/projects.json` to show a list of your projects on the index page.

--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,8 @@ nav:
   articles: /archives/
   projects: http://github.com/probberechts
 
+# Show a Tags section on the home page
+show_tags_section: false
 
 # Links to your social media accounts.
 # The 'icon' keys should correspond to Fontawesome icon names

--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,10 @@ nav:
   projects: http://github.com/probberechts
 
 # Show a Tags section on the home page
-show_tags_section: false
+show_tags_section: true
+
+# Show a Category section on the home page
+show_category_section: true
 
 # Links to your social media accounts.
 # The 'icon' keys should correspond to Fontawesome icon names

--- a/layout/categories.ejs
+++ b/layout/categories.ejs
@@ -1,0 +1,26 @@
+<%- partial('_partial/head') %>
+<div class="page">
+  <div class="post-list">
+    <span class="h1"><a href="<%- url_for('/categories') %>">Categories</a></span>
+    a category wise display of posts 
+    <% if (site.categories && site.categories.length > 0) { %>
+      <ul class="category-list">
+        <% site.categories.forEach(function(category){ %>
+          <li class="category">
+            <b><a href="<%= url_for(category.path) %>"><%= category.name %></a></b> (<%= category.length %>)
+            <ul class="post-list">
+              <% category.posts.forEach(function(post){ %>
+                <li>
+                  <a href="<%= url_for(post.path) %>"><%= post.title %></a>
+                </li>
+              <% }) %>
+            </ul>
+          </li><br />
+        <% }) %>
+      </ul>
+    <% } else { %>
+      <p>No categories found.</p>
+    <% } %>
+  </div>
+</div>
+<%- partial('_partial/footer') %>

--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -89,3 +89,20 @@
   <% } %>
 </section>
 <% } %>
+
+<% if (theme.show_category_section) { %>
+  <section id="categories">
+    <span class="h1"><a href="<%- url_for('/categories') %>">Categories</a></span>
+    <% if (site.categories && site.categories.length > 0) { %>
+      <ul class="category-list">
+        <% site.categories.forEach(function(category){ %>
+          <li class="category">
+            <a href="<%= url_for(category.path) %>"><%= category.name %></a> (<%= category.length %>)
+          </li>
+        <% }) %>
+      </ul>
+    <% } else { %>
+      <p>No categories found.</p>
+    <% } %>
+  </section>
+  <% } %>

--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -72,3 +72,20 @@
   </ul>
 </section>
 <% } %>
+
+<% if (theme.show_tags_section) { %>
+<section id="tags">
+  <span class="h1"><a href="<%- url_for('/tags') %>">Tags</a></span>
+  <% if (site.tags && site.tags.length > 0) { %>
+    <ul class="tag-list">
+      <% site.tags.forEach(function(tag){ %>
+        <li class="tag">
+          <a href="<%= url_for(tag.path) %>"><%= tag.name %></a> (<%= tag.length %>)
+        </li>
+      <% }) %>
+    </ul>
+  <% } else { %>
+    <p>No tags found.</p>
+  <% } %>
+</section>
+<% } %>

--- a/layout/tags.ejs
+++ b/layout/tags.ejs
@@ -1,0 +1,26 @@
+<%- partial('_partial/head') %>
+<div class="page">
+  <div class="post-list">
+    <span class="h1"><a href="<%- url_for('/tags') %>">Tags</a></span>
+    a category wise display of posts 
+    <% if (site.tags && site.tags.length > 0) { %>
+      <ul class="tag-list">
+        <% site.tags.forEach(function(tag){ %>
+          <li class="tag">
+            <b><a href="<%= url_for(tag.path) %>"><%= tag.name %></a></b> (<%= tag.length %>)
+            <ul class="post-list">
+              <% tag.posts.forEach(function(post){ %>
+                <li>
+                  <a href="<%= url_for(post.path) %>"><%= post.title %></a>
+                </li>
+              <% }) %>
+            </ul>
+          </li><br />
+        <% }) %>
+      </ul>
+    <% } else { %>
+      <p>No tags found.</p>
+    <% } %>
+  </div>
+</div>
+<%- partial('_partial/footer') %>

--- a/layout/tags.ejs
+++ b/layout/tags.ejs
@@ -2,7 +2,7 @@
 <div class="page">
   <div class="post-list">
     <span class="h1"><a href="<%- url_for('/tags') %>">Tags</a></span>
-    a category wise display of posts 
+    a tag wise display of posts 
     <% if (site.tags && site.tags.length > 0) { %>
       <ul class="tag-list">
         <% site.tags.forEach(function(tag){ %>


### PR DESCRIPTION
Was working on my blog and looking for this. Saw an issue asking for this (#321) so made a PR for it. Great theme btw!

## Outline of work
**layout updates**:
- [NEW] tags.ejs file to show tags as a separate page.
- [NEW] categories.ejs file to show categories as a separate page.
- [UPDATE] index.ejs file updated with logic to show tags and categories on home page.

**yml config updates**:
- ```show_tags_section``` to show tags on home page.
- ```show_categories_section``` to show categories on home page.

**documentation**:
- [README.md](https://github.com/nkapila6/hexo-theme-cactus?tab=readme-ov-file#category-and-tag-section-on-home-page) updated to reflect this setting.

### Tag and Category on home page
<img width="946" alt="SCR-20240813-pcio" src="https://github.com/user-attachments/assets/79f21a12-c644-403d-9e32-d2c6a57c7634">

### Tags page
<img width="1512" alt="SCR-20240813-osdt" src="https://github.com/user-attachments/assets/9330af64-9c5c-4669-8826-dfd50b20ac83">

### Categories page
<img width="1510" alt="SCR-20240813-pckk" src="https://github.com/user-attachments/assets/dad725c5-6fde-4f69-baf7-ca54825214f3">