### PR TITLE
Feature Added: Word Count and Time To Read

### DIFF
--- a/layout/post.ejs
+++ b/layout/post.ejs
@@ -11,12 +11,9 @@
       <% if (config.symbols_count_time.symbols || config.symbols_count_time.time) { %>
         <span class="meta-divider"> | </span>
         <% if (config.symbols_count_time.symbols) { %>
-          <span class="word-count"><%- symbolsCount(page) %> words</span>
-        <% } %>
-        <% if (config.symbols_count_time.symbols && config.symbols_count_time.time) { %>
-          <span class="meta-divider">, </span>
-        <% } %>
-        <% if (config.symbols_count_time.time) { %>
+          <span class="word-count"><%- symbolsCount(page) %> words</span><%
+        } %><% if (config.symbols_count_time.symbols && config.symbols_count_time.time) { %><span class="meta-divider">, </span><%
+        } %><% if (config.symbols_count_time.time) { %>
           <span class="time-to-read"><%- symbolsTime(page) %></span>
         <% } %>
       <% } %>

--- a/layout/post.ejs
+++ b/layout/post.ejs
@@ -8,6 +8,18 @@
       <%- partial('_partial/post/date', { post: page, class_name: 'postdate' }) %>
       <%- partial('_partial/post/category') %>
       <%- partial('_partial/post/tag') %>
+      <% if (config.symbols_count_time.symbols || config.symbols_count_time.time) { %>
+        <span class="meta-divider"> | </span>
+        <% if (config.symbols_count_time.symbols) { %>
+          <span class="word-count"><%- symbolsCount(page) %> words</span>
+        <% } %>
+        <% if (config.symbols_count_time.symbols && config.symbols_count_time.time) { %>
+          <span class="meta-divider">, </span>
+        <% } %>
+        <% if (config.symbols_count_time.time) { %>
+          <span class="time-to-read"><%- symbolsTime(page) %></span>
+        <% } %>
+      <% } %>
     </div>
   </header>
   <%- partial('_partial/post/gallery') %>


### PR DESCRIPTION
Add word count features to address issue #379

Example outcome:
<img width="1416" height="516" alt="image" src="https://github.com/user-attachments/assets/e15c0c28-f4b0-4add-8389-e2763204e200" />

Usage:
1. Install hexo-word-counter 
```
npm install hexo-word-counter
hexo clean
```
2. Add
```
symbols_count_time:
  symbols: true
  time: true
  total_symbols: false
  total_time: false
  exclude_codeblock: true
  wpm: 275
  suffix: " mins."
```
to Hexo's _config.yml in the root dir of the blog. See more configuration in https://github.com/next-theme/hexo-word-counter.